### PR TITLE
Switch document from named to default import

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-import { document } from "document";
+import document from "document";
 import { Barometer } from "barometer";
 
 console.log("Altimeter starting!");


### PR DESCRIPTION
Attempting to run this example results in the following error:

```
[9:02:02 PM]Unhandled TypeError
[9:02:02 PM]Cannot read property 'getElementById' of undefined
[9:02:02 PM]  at ./app/index.js:6:1
```

and static strings being displayed instead of dynamic labels.  This is due to the curly braces around `document`.  Removing them as I've done here fixes this. :bowtie: 